### PR TITLE
Another try at "xit not found" error (fix #1)

### DIFF
--- a/scripts/safekill.sh
+++ b/scripts/safekill.sh
@@ -13,7 +13,7 @@ function safe_end_procs {
         elif [[ "$pane_proc" == "man" ]] || [[ "$pane_proc" == "less" ]]; then
             cmd='"q"'
         elif [[ "$pane_proc" == "bash" ]] || [[ "$pane_proc" == "zsh" ]] || [[ "$pane_proc" == "fish" ]]; then
-            cmd='C-c C-u "exit" Enter'
+            cmd='C-c C-u space "exit" Enter'
         elif [[ "$pane_proc" == "ssh" ]]; then
             cmd='Enter "~."'
         elif [[ "$pane_proc" == "psql" ]]; then


### PR DESCRIPTION
After upgrading my system (Salix 14.1 to 14.2) I started noticing the problem reported at #1 (but on bash). 

It is not clear what caused the problem, as I'm using the exactly same tmux version (2.2). Despite I'm using the same shell (bash) and terminal (urxvt), it is possible that they version changed, and something may be causing some timing issue. I noticed that adding a space character solves the problem, and " exit" should behave exactly the same as "exit".