### PR TITLE
Forcefully quit with handling if file is in Insert mode for vi-based + Add support for 'vi' process

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,21 @@ Reload TMUX environment:
     # type this in terminal
     $ tmux source-file ~/.tmux.conf
 
+### Configuration
+
+Support the following environment variables which could influence how it proceeds in quiting the processes.
+
+Set it up by creating a new file `~/.bashrc_tmux_safekill` then add the following line per setting you desire to have (you don't have to manually source it,
+it will be automatically picked up internally).
+
+```
+export <CONFIG-NAME>=<VALUE>
+```
+
+wheres you substitue `<CONFIG-NAME>`, and `<VALUE>` according to the following
+
+* `TMUX_SAFEKILL_FORCE` - `1` to attempt quiting processes which support force quit, `0` or other values to just normally quit
+
 ### License
 
 [Apache 2](LICENSE)

--- a/scripts/safekill.sh
+++ b/scripts/safekill.sh
@@ -8,7 +8,7 @@ function safe_end_procs {
     pane_id=$(echo "$pane_set" | awk -F " " '{print $1}')
     pane_proc=$(echo "$pane_set" | awk -F " " '{print tolower($2)}')
     cmd="C-c"
-    if [[ "$pane_proc" == "vim" ]] || [[ "$pane_proc" == "nvim" ]]; then
+    if [[ "$pane_proc" == "vi" ]] || [[ "$pane_proc" == "vim" ]] || [[ "$pane_proc" == "nvim" ]]; then
       cmd='Escape ":qa!" Enter'
     elif [[ "$pane_proc" == "man" ]] || [[ "$pane_proc" == "less" ]]; then
       cmd='"q"'

--- a/scripts/safekill.sh
+++ b/scripts/safekill.sh
@@ -9,7 +9,7 @@ function safe_end_procs {
     pane_proc=$(echo "$pane_set" | awk -F " " '{print tolower($2)}')
     cmd="C-c"
     if [[ "$pane_proc" == "vim" ]] || [[ "$pane_proc" == "nvim" ]]; then
-      cmd='":qa" Enter'
+      cmd='Escape ":qa!" Enter'
     elif [[ "$pane_proc" == "man" ]] || [[ "$pane_proc" == "less" ]]; then
       cmd='"q"'
     elif [[ "$pane_proc" == "bash" ]] || [[ "$pane_proc" == "zsh" ]] || [[ "$pane_proc" == "fish" ]]; then

--- a/scripts/safekill.sh
+++ b/scripts/safekill.sh
@@ -1,15 +1,32 @@
 #!/usr/bin/env bash
 set -e
 
+# non-interactive shell won't source in ~/.bashrc by default
+# use our own bash configuration
+source ~/.bashrc_tmux_safekill
+
+# List of variables interacting with env configurations
+# - 'TMUX_SAFEKILL_FORCE'
+# 1 for set to proceed with forcequit approach, otherwise (default) no forcequit applied
+envcfg_use_forcequit_approach=0
+
+# Bootstrap env configurations
+function read_env_config {
+  if [[ $TMUX_SAFEKILL_FORCE == 1 ]]; then
+    envcfg_use_forcequit_approach=1
+  fi
+}
+
 function safe_end_procs {
   old_ifs="$IFS"
   IFS=$'\n'
+
   for pane_set in $1; do
     pane_id=$(echo "$pane_set" | awk -F " " '{print $1}')
     pane_proc=$(echo "$pane_set" | awk -F " " '{print tolower($2)}')
     cmd="C-c"
     if [[ "$pane_proc" == "vi" ]] || [[ "$pane_proc" == "vim" ]] || [[ "$pane_proc" == "nvim" ]]; then
-      cmd='Escape ":qa!" Enter'
+      cmd=$([[ $envcfg_use_forcequit_approach == 1 ]] && echo 'Escape ":qa!" Enter' || echo 'Escape ":qa" Enter')
     elif [[ "$pane_proc" == "man" ]] || [[ "$pane_proc" == "less" ]]; then
       cmd='"q"'
     elif [[ "$pane_proc" == "bash" ]] || [[ "$pane_proc" == "zsh" ]] || [[ "$pane_proc" == "fish" ]]; then
@@ -40,6 +57,7 @@ function safe_kill_panes_of_current_session {
   done
 }
 
+read_env_config
 safe_kill_panes_of_current_session
 safe_kill_panes_of_current_session
 exit 0

--- a/scripts/safekill.sh
+++ b/scripts/safekill.sh
@@ -3,7 +3,9 @@ set -e
 
 # non-interactive shell won't source in ~/.bashrc by default
 # use our own bash configuration
-source ~/.bashrc_tmux_safekill
+if [ -f ~/.bashrc_tmux_safekill ]; then
+  source ~/.bashrc_tmux_safekill
+fi
 
 # List of variables interacting with env configurations
 # - 'TMUX_SAFEKILL_FORCE'


### PR DESCRIPTION
This changes can be summarized in the following point by point

1. We also send `Escape` key into `tmux send-keys` as it can be that a file is still in insert mode, so it won't hurt to do an escape key signal once before trying to quit.
2. Forcefully quit the file with `:qa!`. Imagine the case of the buffer has been changed (user has edited something, and now in normal mode but he didn't save yet) then if we normally try to quit with `:qa`, vim will complain asking that we should save the file first. Thus it's good idea to forcefully quit it to align with current approach this project uses (another option is to save it).
3. `vi` can be aliased to `vim` just for convenient to launch it from terminal (I have this). The process will list as `vi` still. So added support to cover `vi` as well.

Tested on Ubuntu 20.04 with vim version 8.1, and tmux 3.0a. But should be fine for other variants.