### PR TITLE
Add support for python

### DIFF
--- a/scripts/safekill.sh
+++ b/scripts/safekill.sh
@@ -39,6 +39,8 @@ function safe_end_procs {
       cmd='Enter "~."'
     elif [[ "$pane_proc" == "psql" ]] || [[ "$pane_proc" == "mysql" ]]; then
       cmd='Enter "\q"'
+    elif [[ "$pane_proc" == python* ]]; then
+      cmd='C-d'
     fi
     echo $cmd | xargs tmux send-keys -t "$pane_id"
   done


### PR DESCRIPTION
Works for the python interpreter.
Wildcard matching when running different interpreters: `python`, `python3` etc.
Should work for all virtualenvs like the ones created when running `poetry shell`. I've only tested Poetry though.

Thanks for the plugin @jlipps!